### PR TITLE
Allow HAIstings to pick up where it left off

### DIFF
--- a/src/haistings/haistings.py
+++ b/src/haistings/haistings.py
@@ -3,6 +3,7 @@ import os
 import sys
 import tempfile
 import git
+import pdb
 
 from uuid import uuid4
 
@@ -13,6 +14,7 @@ if not os.environ.get("USER_AGENT"):
 from gitingest import ingest
 from langchain.chat_models import init_chat_model
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.messages import HumanMessage
 from langgraph.graph import START, END, StateGraph, MessagesState
 
 from haistings.k8sreport import buildVulnerabilityReport
@@ -116,20 +118,31 @@ class HAIstingsRuntime:
 
 # Define application steps
 def retrieve(state: State):
+    if len(state["messages"]) > 0:
+        return {}
+
     report = rt.report()
     return {"infrareport": report}
 
 
 def generate_initial(state: State):
-    messages = rt.kickoff_prompt.invoke({
-        "context": state["infrareport"],
-        "question": state["question"],
-        "usercontext": state["usercontext"]
-    })
+    # Revisit the previous conversation
+    if len(state["messages"]) > 0:
+        messages = state["messages"] + \
+           [HumanMessage("Given all the context available, especially the extra "
+                         "context provided by the system administrator, "
+                         "Can you generate another prioritized report?")]
+    else:
+        messages = rt.kickoff_prompt.invoke({
+            "context": state["infrareport"],
+            "question": state["question"],
+            "usercontext": state["usercontext"]
+        }).to_messages()
     response = rt.llm.invoke(messages, config=rt.rtconfig)
+    print(response.content)
 
     return {
-        "messages": response,
+        "messages": messages + [response],
         "answer": response.content,
     }
 
@@ -146,17 +159,18 @@ Please provide more information to help the assistant provide a better response:
     print(text_separator())
 
     prompt = ChatPromptTemplate.from_messages([
-        ("user", "Here's extra context to help with the prioritization: {extra}. "
+        ("user", "Here's extra context to help with the prioritization by the system administrator:\n\n"
+                 "{extra}.\n\n"
                  "Given this new information, can you provide a better response?"),
     ])
 
     prompt_msg = prompt.invoke({"extra": extra})
-
     messages = messages + prompt_msg.to_messages()
 
     response = rt.llm.invoke(messages, config=rt.rtconfig)
+    print(response.content)
     return {
-        "messages": response,
+        "messages": prompt_msg.to_messages() + [response],
         "answer": response.content,
     }
 
@@ -231,6 +245,14 @@ def do(top: int, model: str, model_provider: str, api_key: str, base_url: str, n
     # Compile the graph
     graph = graph_builder.compile(checkpointer=memory)
 
+    # Determine if we can continue from a previous state
+    all_states = [s for s in graph.get_state_history(rt.rtconfig)]
+
+    if len(all_states) >= 1:
+        # Override the configuration with the last state
+        rt.rtconfig = all_states[0].config
+        print("Starting from checkpoint: {}".format(rt.rtconfig["configurable"]["checkpoint_id"]))
+
     kickoff_question = "What are the top vulnerabilities in the infrastructure?"
 
     # Start the conversation
@@ -238,13 +260,7 @@ def do(top: int, model: str, model_provider: str, api_key: str, base_url: str, n
         "question": kickoff_question,
         "usercontext": notes,
     }, config=rt.rtconfig, stream_mode="messages"):
-        # If it's a tuple, get the first item
-        if isinstance(chunk, tuple):
-            chunk = chunk[0]
-        if hasattr(chunk, "content"):
-            print(chunk.content, end="")
-        else:
-            print(chunk, end="")
+        pass
 
 
 def main():


### PR DESCRIPTION
This allows HAIstings to continue the conversation, generating more
relevant reports, if there is something to pick up from.

Problematically, we can't use the streaming responses because langgraph
prints randomly the messages for some reason... Even if it should just
append. So, in order to keep state AND print only relevant bits, I moved
the printing logic to the nodes.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
